### PR TITLE
multirec.cabal: add missing examples files to tarball

### DIFF
--- a/multirec.cabal
+++ b/multirec.cabal
@@ -44,10 +44,13 @@ extra-source-files:   examples/All.hs
                       examples/ASTUse.hs
                       examples/ASTTHUse.hs
                       examples/ASTExamples.hs
+                      examples/J.hs
+                      examples/GRose.hs
                       examples/Single.hs
                       examples/SingleUse.hs
                       examples/SingleTHUse.hs
                       examples/SingleExamples.hs
+                      examples/VarTypes.hs
                       CREDITS
 
 source-repository head


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <siarheit@google.com>